### PR TITLE
Fix response mapping on delete routes

### DIFF
--- a/src/restClient.js
+++ b/src/restClient.js
@@ -52,6 +52,7 @@ export default client => {
     switch (type) {
       case GET_ONE:
       case UPDATE:
+      case DELETE:
         return { data: response };
       case CREATE:
         return { data: {...params.data, id: response.id} };

--- a/test/restClient.spec.js
+++ b/test/restClient.spec.js
@@ -203,7 +203,7 @@ describe('Rest Client', function () {
 
     it('returns the data returned by the client', function () {
       return asyncResult.then(result => {
-        expect(result).to.deep.equal(removeResult);
+        expect(result).to.deep.equal({ data: removeResult });
       });
     });
   });


### PR DESCRIPTION
This PR fixes the response format on `DELETE` type

Docs: https://github.com/marmelab/admin-on-rest/blob/5deff75174cbba344f5d851bbf4802e98f56c78d/docs/RestClients.md#response-format
> ### Response Format
> 
> REST responses are objects. The format depends on the type.
> 
> Type                 | Response format
> -------------------- | ----------------
> `GET_LIST`           | `{ data: {Record[]}, total: {int} }`
> `GET_ONE`            | `{ data: {Record} }`
> `CREATE`             | `{ data: {Record} }`
> `UPDATE`             | `{ data: {Record} }`
> `DELETE`             | `{ data: {Record} }`
> `GET_MANY`           | `{ data: {Record[]} }`
> `GET_MANY_REFERENCE` | `{ data: {Record[]}, total: {int} }`
> 
> A `{Record}` is an object literal with at least an `id` property, e.g. `{ id: 123, title: "hello, world" }`.
