### PR TITLE
Add feathers-client as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "homepage": "https://github.com/josx/aor-feathers-client#readme",
   "peerDependencies": {
-    "admin-on-rest": "^1.0.1"
+    "admin-on-rest": "^1.0.1",
+    "feathers-client": "^1.9.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
By adding this PR to the project, 'yarn add' or 'npm install' will warn on missing dependency on feathers-client.