### PR TITLE
Implements AUTH_ERROR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ For using [feathers](https://www.feathersjs.com) with [admin-on-rest](https://gi
 * AUTH_LOGIN
 * AUTH_LOGOUT
 * AUTH_CHECK
+* AUTH_ERROR
 * Custom Id support
 
 ## Installation

--- a/src/authClient.js
+++ b/src/authClient.js
@@ -2,6 +2,7 @@ import {
   AUTH_LOGIN,
   AUTH_LOGOUT,
   AUTH_CHECK,
+  AUTH_ERROR,
 } from 'admin-on-rest';
 
 export default (client, options = {}) => (type, params) => {
@@ -25,6 +26,13 @@ export default (client, options = {}) => (type, params) => {
       return client.logout();
     case AUTH_CHECK:
       return localStorage.getItem(storageKey) ? Promise.resolve() : Promise.reject();
+    case AUTH_ERROR:
+      const { status } = params;
+      if (status === 401) {
+        localStorage.removeItem(storageKey);
+        return Promise.reject();
+      }
+      return Promise.resolve();
     default:
       throw new Error(`Unsupported FeathersJS authClient action type ${type}`);
   }

--- a/src/authClient.js
+++ b/src/authClient.js
@@ -27,8 +27,8 @@ export default (client, options = {}) => (type, params) => {
     case AUTH_CHECK:
       return localStorage.getItem(storageKey) ? Promise.resolve() : Promise.reject();
     case AUTH_ERROR:
-      const { status } = params;
-      if (status === 401) {
+      const { code } = params;
+      if (code === 401) {
         localStorage.removeItem(storageKey);
         return Promise.reject();
       }


### PR DESCRIPTION
Fixes #31 
admin-on-rest 1.0 requires the authClient to implement AUTH_ERROR event.
Otherwise any http error returned from the server such as 403, 404 etc
would cause auto logout of the user.

https://marmelab.com/blog/2017/04/26/admin-on-rest-1-0.html#the-authentication-logic-moved-to-saga