### PR TITLE
usePatch: Do object-diff only when params.previousData is present

### DIFF
--- a/src/restClient.js
+++ b/src/restClient.js
@@ -54,7 +54,8 @@ export default (client, options = {}) => {
         return service.get(params.id)
       case UPDATE:
         if (usePatch) {
-          return service.patch(params.id, diff(params.previousData, params.data))
+          const data = params.previousData ? diff(params.previousData, params.data) : params.data
+          return service.patch(params.id, data)
         }
         return service.update(params.id, params.data)
       case CREATE:


### PR DESCRIPTION
This is an improvement on #49 
I have observed that admin-on-rest does not sent params.previousData for UPDATE in some cases. Check for this and only do object-diff if params.previousData exists.