### PR TITLE
CREATE: adding backend api response to dataprovider response

### DIFF
--- a/src/restClient.js
+++ b/src/restClient.js
@@ -76,7 +76,7 @@ export default (client, options = {}) => {
       case DELETE:
         return {data: {...response, id: response[idKey]}}
       case CREATE:
-        return {data: {...params.data, id: response[idKey]}}
+        return {data: { ...params.data, ...response, id: response[idKey]}}
       case GET_MANY_REFERENCE: // fix GET_MANY_REFERENCE missing id
       case GET_MANY: // fix GET_MANY missing id
       case GET_LIST:


### PR DESCRIPTION
Not always when you call create you will recieve the params you sent, eg file upload o a custom create.