### PR TITLE
Add redirectTo to options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1205,6 +1205,14 @@
         "type-detect": "^1.0.0"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -1223,6 +1231,11 @@
       "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
       "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=",
       "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "chokidar": {
       "version": "1.7.0",
@@ -1712,14 +1725,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1734,20 +1745,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1864,8 +1872,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1877,7 +1884,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1892,7 +1898,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1900,14 +1905,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1926,7 +1929,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2007,8 +2009,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2020,7 +2021,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2142,7 +2142,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@feathersjs/client": "^3.5.3"
   },
   "dependencies": {
+    "chai-as-promised": "^7.1.1",
     "debug": "^3.0.0",
     "jwt-decode": "^2.2.0",
     "object-diff": "^0.0.4"

--- a/src/authClient.js
+++ b/src/authClient.js
@@ -14,7 +14,8 @@ export default (client, options = {}) => (type, params) => {
     permissionsKey,
     permissionsField,
     passwordField,
-    usernameField
+    usernameField,
+    redirectTo
   } = Object.assign({}, {
       storageKey: 'token',
       authenticate: { type: 'local' },
@@ -36,7 +37,7 @@ export default (client, options = {}) => (type, params) => {
       localStorage.removeItem(permissionsKey);
       return client.logout();
     case AUTH_CHECK:
-      return localStorage.getItem(storageKey) ? Promise.resolve() : Promise.reject();
+      return localStorage.getItem(storageKey) ? Promise.resolve() : Promise.reject({ redirectTo });
     case AUTH_ERROR:
       const { code } = params
       if (code === 401 || code === 403) {

--- a/test/authClient.spec.js
+++ b/test/authClient.spec.js
@@ -1,0 +1,96 @@
+"use strict";
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const sinon = require('sinon');
+const aorAuthClient = require('../lib').authClient;
+
+const { expect } = chai;
+chai.use(chaiAsPromised);
+
+const debug = require('debug')
+
+const dbg = debug('aor-feathers-client:test')
+
+const fakeClient = {
+  // authenticate: ({ email, password }) => { ... }
+};
+
+let authClient;
+
+const options = {
+  storageKey: 'storageKey'
+};
+
+function setupClient(options = {}) {
+  authClient = aorAuthClient(fakeClient, options)
+}
+
+
+
+describe('Auth Client', function () {
+  describe('when called with AUTH_CHECK', function () {
+
+    describe('when [storageKey] is not set', function() {
+      beforeEach(function() {
+        setupClient(options);
+        global.localStorage = {
+          getItem: sinon.stub().returns()
+        }
+      });
+
+      afterEach(function() {
+        delete global.localStorage;
+      });
+
+      it('should reject', function () {
+        return expect(authClient('AUTH_CHECK', {})).to.be.rejected;
+      });
+
+      describe('when redirectTo is set', function() {
+        let testOptions = Object.assign({}, options, { redirectTo: '/someurl' })
+        beforeEach(function() {
+          setupClient(testOptions);
+        });
+
+        it('should reject with the redirectTo URL', function() {
+          return expect(authClient('AUTH_CHECK', {})).to.be.rejectedWith({ redirectTo: testOptions.redirectTo });
+        });
+      })
+    });
+
+    describe('when [storageKey] is set', function() {
+      before(function() {
+        global.localStorage = {
+          getItem: sinon.stub().returns('somedata')
+        }
+      });
+      after(function() {
+        delete global.localStorage;
+      });
+
+      it('should resolve', function() {
+        return expect(authClient('AUTH_CHECK', {})).to.be.fulfilled;
+      });
+    });
+  });
+
+  describe('when called with an invalid type', function () {
+    beforeEach(function () {
+      setupClient();
+    });
+
+    it('should throw an error', function () {
+      const errorRes = new Error('Unsupported FeathersJS authClient action type WRONG_TYPE')
+      try {
+        return authClient('WRONG_TYPE', 'posts', {})
+          .then(result => {
+            throw new Error("client must reject");
+          })
+          .catch(err => {});
+      } catch (err) {
+        expect(err).to.deep.equal(errorRes);
+      }
+    });
+  });
+});


### PR DESCRIPTION
redirectTo is used when AUTH_CHECK fails. If an auth session expires, etc, the user will be redirected to the path set in redirectTo

This PR adds the redirectTo option, as well as some rudimentary testing

Implements #59